### PR TITLE
Fix #1691: adding fails on large directories

### DIFF
--- a/adder/util.go
+++ b/adder/util.go
@@ -3,7 +3,6 @@ package adder
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/ipfs-cluster/ipfs-cluster/api"
@@ -165,7 +164,7 @@ func (dag BaseDAGService) Get(ctx context.Context, key cid.Cid) (ipld.Node, erro
 // GetMany returns an output channel that always emits an error
 func (dag BaseDAGService) GetMany(ctx context.Context, keys []cid.Cid) <-chan *ipld.NodeOption {
 	out := make(chan *ipld.NodeOption, 1)
-	out <- &ipld.NodeOption{Err: fmt.Errorf("failed to fetch all nodes")}
+	out <- &ipld.NodeOption{Err: errors.New("failed to fetch all nodes")}
 	close(out)
 	return out
 }

--- a/adder/util.go
+++ b/adder/util.go
@@ -148,7 +148,7 @@ func Pin(ctx context.Context, rpc *rpc.Client, pin api.Pin) error {
 }
 
 // ErrDAGNotFound is returned whenever we try to get a block from the DAGService.
-var ErrDAGNotFound = errors.New("dagservice: block not found")
+var ErrDAGNotFound = errors.New("dagservice: a Get operation was attempted while cluster-adding (this is likely a bug)")
 
 // BaseDAGService partially implements an ipld.DAGService.
 // It provides the methods which are not needed by ClusterDAGServices
@@ -164,7 +164,7 @@ func (dag BaseDAGService) Get(ctx context.Context, key cid.Cid) (ipld.Node, erro
 // GetMany returns an output channel that always emits an error
 func (dag BaseDAGService) GetMany(ctx context.Context, keys []cid.Cid) <-chan *ipld.NodeOption {
 	out := make(chan *ipld.NodeOption, 1)
-	out <- &ipld.NodeOption{Err: errors.New("failed to fetch all nodes")}
+	out <- &ipld.NodeOption{Err: ErrDAGNotFound}
 	close(out)
 	return out
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/ipfs/go-merkledag v0.6.0
 	github.com/ipfs/go-mfs v0.1.3-0.20210507195338-96fbfa122164
 	github.com/ipfs/go-path v0.3.0
-	github.com/ipfs/go-unixfs v0.3.1
+	github.com/ipfs/go-unixfs v0.4.0
 	github.com/ipld/go-car v0.3.3
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kishansagathiya/go-dot v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -602,6 +602,10 @@ github.com/ipfs/go-unixfs v0.2.4/go.mod h1:SUdisfUjNoSDzzhGVxvCL9QO/nKdwXdr+gbMU
 github.com/ipfs/go-unixfs v0.2.6/go.mod h1:GTTzQvaZsTZARdNkkdjDKFFnBhmO3e5mIM1PkH/x4p0=
 github.com/ipfs/go-unixfs v0.3.1 h1:LrfED0OGfG98ZEegO4/xiprx2O+yS+krCMQSp7zLVv8=
 github.com/ipfs/go-unixfs v0.3.1/go.mod h1:h4qfQYzghiIc8ZNFKiLMFWOTzrWIAtzYQ59W/pCFf1o=
+github.com/ipfs/go-unixfs v0.3.2-0.20220615181143-9ac1b9ff0917 h1:TzNOzSioqAfd6VQS8+PWAnKH4M7shjyDVe6iSvQO7HE=
+github.com/ipfs/go-unixfs v0.3.2-0.20220615181143-9ac1b9ff0917/go.mod h1:I7Nqtm06HgOOd+setAoCU6rf/HgVFHE+peeNuOv/5+g=
+github.com/ipfs/go-unixfs v0.4.0 h1:qSyyxfB/OiDdWHYiSbyaqKC7zfSE/TFL0QdwkRjBm20=
+github.com/ipfs/go-unixfs v0.4.0/go.mod h1:I7Nqtm06HgOOd+setAoCU6rf/HgVFHE+peeNuOv/5+g=
 github.com/ipfs/go-unixfsnode v1.1.2/go.mod h1:5dcE2x03pyjHk4JjamXmunTMzz+VUtqvPwZjIEkfV6s=
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=


### PR DESCRIPTION
The issue happened because transparently upgrading to a HAMT directory attempted to read from our write-only ClusterDAGService. See #1691.