### PR TITLE
PinSVC API: fix bugs and increase compliance

### DIFF
--- a/api/pinsvcapi/config.go
+++ b/api/pinsvcapi/config.go
@@ -67,7 +67,10 @@ func NewConfig() *Config {
 	cfg.DefaultFunc = defaultFunc
 	cfg.APIErrorFunc = func(err error, status int) error {
 		return pinsvc.APIError{
-			Reason: err.Error(),
+			Details: pinsvc.APIErrorDetails{
+				Reason:  err.Error(),
+				Details: err.Error(),
+			},
 		}
 	}
 	return &cfg

--- a/api/pinsvcapi/config.go
+++ b/api/pinsvcapi/config.go
@@ -68,8 +68,7 @@ func NewConfig() *Config {
 	cfg.APIErrorFunc = func(err error, status int) error {
 		return pinsvc.APIError{
 			Details: pinsvc.APIErrorDetails{
-				Reason:  err.Error(),
-				Details: err.Error(),
+				Reason: err.Error(),
 			},
 		}
 	}

--- a/api/pinsvcapi/pinsvc/pinsvc.go
+++ b/api/pinsvcapi/pinsvc/pinsvc.go
@@ -24,12 +24,17 @@ func init() {
 // APIError is returned by the API as a body when an error
 // occurs. It implements the error interface.
 type APIError struct {
+	Details APIErrorDetails `json:"error"`
+}
+
+// APIErrorDetails contains details about the APIError.
+type APIErrorDetails struct {
 	Reason  string `json:"reason"`
-	Details string `json:"details"`
+	Details string `json:"details,omitempty"`
 }
 
 func (apiErr APIError) Error() string {
-	return apiErr.Reason
+	return apiErr.Details.Reason
 }
 
 // PinName is a string limited to 255 chars when serializing JSON.
@@ -54,9 +59,9 @@ func (pname *PinName) UnmarshalJSON(data []byte) error {
 // Pin contains basic information about a Pin and pinning options.
 type Pin struct {
 	Cid     types.Cid         `json:"cid"`
-	Name    PinName           `json:"name"`
-	Origins []types.Multiaddr `json:"origins"`
-	Meta    map[string]string `json:"meta"`
+	Name    PinName           `json:"name,omitempty"`
+	Origins []types.Multiaddr `json:"origins,omitempty"`
+	Meta    map[string]string `json:"meta,omitempty"`
 }
 
 // Defined returns if the pinis empty (Cid not set).
@@ -221,12 +226,12 @@ type PinStatus struct {
 	Created   time.Time         `json:"created"`
 	Pin       Pin               `json:"pin"`
 	Delegates []types.Multiaddr `json:"delegates"`
-	Info      map[string]string `json:"info"`
+	Info      map[string]string `json:"info,omitempty"`
 }
 
 // PinList is the result of a call to List pins
 type PinList struct {
-	Count   int         `json:"count"`
+	Count   uint64      `json:"count"`
 	Results []PinStatus `json:"results"`
 }
 
@@ -293,6 +298,8 @@ func (lo *ListOptions) FromQuery(q url.Values) error {
 			return fmt.Errorf("error parsing 'limit' query param: %s: %w", v, err)
 		}
 		lo.Limit = lim
+	} else {
+		lo.Limit = 10 // implicit default
 	}
 
 	if meta := q.Get("meta"); meta != "" {

--- a/api/pinsvcapi/pinsvcapi_test.go
+++ b/api/pinsvcapi/pinsvcapi_test.go
@@ -116,14 +116,14 @@ func TestAPIListEndpoint(t *testing.T) {
 		// Test with cids+limit
 		var resp8 pinsvc.PinList
 		test.MakeGet(t, svcapi, url(svcapi)+"/pins?cid=QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmq,QmP63DkAFEnDYNjDYBpyNDfttu1fvUw99x1brscPzpqmmb&limit=1", &resp8)
-		if resp8.Count != 1 {
+		if resp8.Count != 2 || len(resp8.Results) != 1 {
 			t.Errorf("unexpected statusAll+cids+limit resp:\n %+v", resp8)
 		}
 
 		// Test with limit
 		var resp9 pinsvc.PinList
 		test.MakeGet(t, svcapi, url(svcapi)+"/pins?limit=1", &resp9)
-		if resp9.Count != 1 {
+		if resp9.Count != 3 || len(resp9.Results) != 1 {
 			t.Errorf("unexpected statusAll+limit=1 resp:\n %+v", resp9)
 		}
 
@@ -143,8 +143,8 @@ func TestAPIListEndpoint(t *testing.T) {
 
 		var errorResp pinsvc.APIError
 		test.MakeGet(t, svcapi, url(svcapi)+"/pins?status=invalid", &errorResp)
-		if errorResp.Reason == "" {
-			t.Errorf("expected an error: %s", errorResp.Reason)
+		if errorResp.Details.Reason == "" {
+			t.Errorf("expected an error: %s", errorResp.Details.Reason)
 		}
 	}
 
@@ -200,7 +200,7 @@ func TestAPIPinEndpoint(t *testing.T) {
 			t.Fatal(err)
 		}
 		test.MakePost(t, svcapi, url(svcapi)+"/pins", pinJSON, &errName)
-		if !strings.Contains(errName.Reason, "255") {
+		if !strings.Contains(errName.Details.Reason, "255") {
 			t.Error("expected name error")
 		}
 	}
@@ -231,7 +231,7 @@ func TestAPIGetPinEndpoint(t *testing.T) {
 
 		var err pinsvc.APIError
 		test.MakeGet(t, svcapi, url(svcapi)+"/pins/"+clustertest.ErrorCid.String(), &err)
-		if err.Reason == "" {
+		if err.Details.Reason == "" {
 			t.Error("expected an error")
 		}
 	}


### PR DESCRIPTION
These changes fix a few bugs in the PinSVC API and have been discovered by
running the compliance tool at https://github.com/ipfs-shipyard/pinning-service-compliance.

In particular, the error objects did not respect the spec, filters and counts
were not done right. An additional PR will follow with fixes to the pintracker
because some pin status information was not correctly set.