### PR TITLE
pintracker: fix status objects missing or having wrong fields

### DIFF
--- a/pintracker/optracker/operationtracker.go
+++ b/pintracker/optracker/operationtracker.go
@@ -154,9 +154,12 @@ func (opt *OperationTracker) SetError(ctx context.Context, c api.Cid, err error)
 func (opt *OperationTracker) unsafePinInfo(ctx context.Context, op *Operation, ipfs api.IPFSID) api.PinInfo {
 	if op == nil {
 		return api.PinInfo{
-			Cid:  api.CidUndef,
-			Peer: opt.pid,
-			Name: "",
+			Cid:     api.CidUndef,
+			Name:    "",
+			Peer:    opt.pid,
+			Origins: nil,
+			//Created:  0,
+			Metadata: nil,
 			PinInfoShort: api.PinInfoShort{
 				PeerName:     opt.peerName,
 				IPFS:         "",
@@ -169,9 +172,13 @@ func (opt *OperationTracker) unsafePinInfo(ctx context.Context, op *Operation, i
 		}
 	}
 	return api.PinInfo{
-		Cid:  op.Cid(),
-		Peer: opt.pid,
-		Name: op.Pin().Name,
+		Cid:         op.Cid(),
+		Name:        op.Pin().Name,
+		Peer:        opt.pid,
+		Allocations: op.Pin().Allocations,
+		Origins:     op.Pin().Origins,
+		Created:     op.Pin().Timestamp,
+		Metadata:    op.Pin().Metadata,
 		PinInfoShort: api.PinInfoShort{
 			PeerName:      opt.peerName,
 			IPFS:          ipfs.ID,

--- a/pintracker/stateless/stateless_test.go
+++ b/pintracker/stateless/stateless_test.go
@@ -513,7 +513,7 @@ func TestAttemptCountAndPriority(t *testing.T) {
 	normalPin2 := api.PinWithOpts(test.Cid4, pinOpts)
 	errPin := api.PinWithOpts(pinErrCid, pinOpts)
 
-	spt := testStatelessPinTracker(t, normalPin, normalPin2)
+	spt := testStatelessPinTracker(t, normalPin, normalPin2, errPin)
 	defer spt.Shutdown(ctx)
 
 	st := spt.Status(ctx, test.Cid1)


### PR DESCRIPTION
The operation tracker was not setting some fields correctly when producing
PinInfo objects. Additionally, recover operations were submitted with empty
pin objects, which resulted in the status for pins sent on recover operations
to be missing fields.