### PR TITLE
ctl: Expiration date in "pin ls" was showing wrong field (timestamp)

### DIFF
--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -241,7 +241,7 @@ func textFormatPrintPin(obj api.Pin) {
 	}
 	expireAt := "∞"
 	if !obj.ExpireAt.IsZero() {
-		expireAt = obj.Timestamp.Format("2006-01-02 15:04:05")
+		expireAt = obj.ExpireAt.Format("2006-01-02 15:04:05")
 	}
 	fmt.Printf(" | Exp: %s", expireAt)
 


### PR DESCRIPTION
Fixes #1666.