### PR TITLE
Fix: operationtracker metrics go negative

### DIFF
--- a/pintracker/optracker/operation.go
+++ b/pintracker/optracker/operation.go
@@ -89,7 +89,6 @@ func newOperation(ctx context.Context, pin api.Pin, typ OperationType, ph Phase,
 		ts:           time.Now(),
 		error:        "",
 	}
-	tracker.recordMetricUnsafe(op, 1)
 	return op
 }
 
@@ -126,7 +125,6 @@ func (op *Operation) Context() context.Context {
 func (op *Operation) Cancel() {
 	_, span := trace.StartSpan(op.ctx, "optracker/Cancel")
 	op.cancel()
-	op.tracker.recordMetric(op, -1)
 	span.End()
 }
 

--- a/pintracker/optracker/operationtracker.go
+++ b/pintracker/optracker/operationtracker.go
@@ -91,6 +91,7 @@ func (opt *OperationTracker) TrackNewOperation(ctx context.Context, pin api.Pin,
 		}
 		// i.e. operations in error phase
 		// i.e. pin operations that need to be canceled for unpinning
+		op.tracker.recordMetric(op, -1)
 		op.Cancel() // cancel ongoing operation and replace it
 	}
 
@@ -102,6 +103,7 @@ func (opt *OperationTracker) TrackNewOperation(ctx context.Context, pin api.Pin,
 	}
 	logger.Debugf("'%s' on cid '%s' has been created with phase '%s'", typ, pin.Cid, ph)
 	opt.operations[pin.Cid] = op2
+	opt.recordMetricUnsafe(op2, 1)
 	return op2
 }
 


### PR DESCRIPTION
By substracing 1 on every cancel we are double-counting.