### PR TITLE
Fix docker build failure (git safe directory)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ WORKDIR $SRC_PATH
 RUN go mod download
 
 COPY --chown=1000:users . $SRC_PATH
+RUN git config --global --add safe.directory /go/src/github.com/ipfs-cluster/ipfs-cluster
 RUN make install
 
 

--- a/Dockerfile-bundle
+++ b/Dockerfile-bundle
@@ -15,6 +15,7 @@ WORKDIR $SRC_PATH
 RUN go mod download
 
 COPY --chown=1000:users . $SRC_PATH
+RUN git config --global --add safe.directory /go/src/github.com/ipfs-cluster/ipfs-cluster
 RUN make install
 
 #------------------------------------------------------

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -17,6 +17,7 @@ WORKDIR $SRC_PATH
 RUN go mod download
 
 COPY --chown=1000:users . $SRC_PATH
+RUN git config --global --add safe.directory /go/src/github.com/ipfs-cluster/ipfs-cluster
 RUN make install
 
 #------------------------------------------------------


### PR DESCRIPTION
Git refuses to run `git rev-parse HEAD` now, in docker.