### PR TITLE
ipfsconn: do not error when we cannot parse multiaddresses from ipfs.

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -373,8 +373,8 @@ func (ipfs *Connector) ID(ctx context.Context) (api.IPFSID, error) {
 	for i, strAddr := range res.Addresses {
 		mAddr, err := api.NewMultiaddr(strAddr)
 		if err != nil {
-			id.Error = err.Error()
-			return id, err
+			logger.Warningf("cannot parse IPFS multiaddress: %s (%w)... ignoring", strAddr, err)
+			continue
 		}
 		mAddrs[i] = mAddr
 	}


### PR DESCRIPTION
Fixes: #1835.

If IPFS introduces a new multiaddress type/string that we have not compiled, we error. This caused issues with latest ipfs version (which we fixed by upgrading libraries too). This makes cluster a bit more future proof with upcoming ipfs versions.