### PR TITLE
Switch Dockerfiles to use Pebble datastore backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ENV GOPATH                 /go
 ENV SRC_PATH               /go/src/github.com/ipfs-cluster/ipfs-cluster
 ENV IPFS_CLUSTER_PATH      /data/ipfs-cluster
 ENV IPFS_CLUSTER_CONSENSUS crdt
-ENV IPFS_CLUSTER_DATASTORE leveldb
+ENV IPFS_CLUSTER_DATASTORE pebble
 
 EXPOSE 9094
 EXPOSE 9095

--- a/Dockerfile-bundle
+++ b/Dockerfile-bundle
@@ -29,7 +29,7 @@ ENV GOPATH                 /go
 ENV SRC_PATH               /go/src/github.com/ipfs-cluster/ipfs-cluster
 ENV IPFS_CLUSTER_PATH      /data/ipfs-cluster
 ENV IPFS_CLUSTER_CONSENSUS crdt
-ENV IPFS_CLUSTER_DATASTORE leveldb
+ENV IPFS_CLUSTER_DATASTORE pebble
 
 EXPOSE 9094
 EXPOSE 9095

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -31,7 +31,7 @@ ENV GOPATH                                      /go
 ENV SRC_PATH                                    /go/src/github.com/ipfs-cluster/ipfs-cluster
 ENV IPFS_CLUSTER_PATH                           /data/ipfs-cluster
 ENV IPFS_CLUSTER_CONSENSUS                      crdt
-ENV IPFS_CLUSTER_DATASTORE                      leveldb
+ENV IPFS_CLUSTER_DATASTORE                      pebble
 ENV IPFS_CLUSTER_RESTAPI_HTTPLISTENMULTIADDRESS /ip4/0.0.0.0/tcp/9094
 ENV IPFS_CLUSTER_IPFSPROXY_LISTENMULTIADDRESS   /ip4/0.0.0.0/tcp/9095
 


### PR DESCRIPTION
LevelDB was set for reasons that I don't remember. It might have been related to reduce the amount of space used by cluster. Pebble is most likely a better choice for Docker containers.