### PR TITLE
chore: switch to ipfs/kubo docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,8 +163,8 @@ jobs:
     - name: Make install
       run: make install
 
-    - name: Pull go-ipfs
-      run: docker pull ipfs/go-ipfs
+    - name: Pull kubo
+      run: docker pull ipfs/kubo
 
     - name: Sharness
       run: make test_sharness

--- a/Dockerfile-bundle
+++ b/Dockerfile-bundle
@@ -1,8 +1,8 @@
 FROM golang:1.19-buster AS builder
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
 
-# This dockerfile builds cluster and runs it along with go-ipfs.
-# It re-uses the latest go-ipfs:release container.
+# This dockerfile builds cluster and runs it along with kubo.
+# It re-uses the latest kubo:release container.
 
 # This builder just builds the cluster binaries
 ENV GOPATH      /go
@@ -19,11 +19,11 @@ RUN git config --global --add safe.directory /go/src/github.com/ipfs-cluster/ipf
 RUN make install
 
 #------------------------------------------------------
-FROM ipfs/go-ipfs:release
+FROM ipfs/kubo:release
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
 
 # This is the container which just puts the previously
-# built binaries on the go-ipfs-container.
+# built binaries on the kubo-container.
 
 ENV GOPATH                 /go
 ENV SRC_PATH               /go/src/github.com/ipfs-cluster/ipfs-cluster

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -21,11 +21,11 @@ RUN git config --global --add safe.directory /go/src/github.com/ipfs-cluster/ipf
 RUN make install
 
 #------------------------------------------------------
-FROM ipfs/go-ipfs:master
+FROM ipfs/kubo:master-latest
 MAINTAINER Hector Sanjuan <hector@protocol.ai>
 
 # This is the container which just puts the previously
-# built binaries on the go-ipfs-container.
+# built binaries on the kubo-container.
 
 ENV GOPATH                                      /go
 ENV SRC_PATH                                    /go/src/github.com/ipfs-cluster/ipfs-cluster

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 There are 3 different applications:
 
-* A cluster peer application: `ipfs-cluster-service`, to be run along with `go-ipfs` as a sidecar.
+* A cluster peer application: `ipfs-cluster-service`, to be run along with `kubo` (`go-ipfs`) as a sidecar.
 * A client CLI application: `ipfs-cluster-ctl`, which allows easily interacting with the peer's HTTP API.
 * An additional "follower" peer application: `ipfs-cluster-follow`, focused on simplifying the process of configuring and running follower peers.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 # This is an example docker-compose file to quickly test an IPFS Cluster
 # with multiple peers on a contained environment.
 
-# It runs 3 cluster peers (cluster0, cluster1...) attached to go-ipfs daemons
+# It runs 3 cluster peers (cluster0, cluster1...) attached to kubo daemons
 # (ipfs0, ipfs1...) using the CRDT consensus component. Cluster peers
 # autodiscover themselves using mDNS on the docker internal network.
 #
@@ -34,7 +34,7 @@ services:
 
   ipfs0:
     container_name: ipfs0
-    image: ipfs/go-ipfs:latest
+    image: ipfs/kubo:release
 #   ports:
 #     - "4001:4001" # ipfs swarm - expose if needed/wanted
 #     - "5001:5001" # ipfs api - expose if needed/wanted
@@ -72,7 +72,7 @@ services:
 # See Cluster PEER 0 for comments (all removed here and below)
   ipfs1:
     container_name: ipfs1
-    image: ipfs/go-ipfs:latest
+    image: ipfs/kubo:release
     volumes:
       - ./compose/ipfs1:/data/ipfs
 
@@ -97,7 +97,7 @@ services:
 # See Cluster PEER 0 for comments (all removed here and below)
   ipfs2:
     container_name: ipfs2
-    image: ipfs/go-ipfs:latest
+    image: ipfs/kubo:release
     volumes:
       - ./compose/ipfs2:/data/ipfs
 

--- a/sharness/lib/test-lib.sh
+++ b/sharness/lib/test-lib.sh
@@ -33,9 +33,9 @@ test_ipfs_init() {
     if docker ps --format '{{.Names}}' | egrep -q '^ipfs$'; then
         echo "ipfs container already running"
     else
-        docker run --name ipfs -d -p 127.0.0.1:5001:5001 ipfs/go-ipfs > /dev/null 2>&1
+        docker run --name ipfs -d -p 127.0.0.1:5001:5001 ipfs/kubo > /dev/null 2>&1
         if [ $? -ne 0 ]; then
-            echo "IPFS init FAIL: Error running go-ipfs in docker."
+            echo "IPFS init FAIL: Error running kubo in docker."
             exit 1
         fi
         while ! curl -s "localhost:5001/api/v0/version" > /dev/null; do


### PR DESCRIPTION
@hsanjuan we are still dual publishing under both names, but it is safer to use the new name.

