### PR TITLE
Send readiness notification to systemd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cockroachdb/pebble v0.0.0-20230227185959-8285e8dd5c08
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dgraph-io/badger v1.6.2
 	github.com/dgraph-io/badger/v3 v3.2103.5
 	github.com/dustin/go-humanize v1.0.1
@@ -86,7 +87,6 @@ require (
 	github.com/cockroachdb/redact v1.0.8 // indirect
 	github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 // indirect
 	github.com/containerd/cgroups v1.0.4 // indirect
-	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 // indirect
 	github.com/cskr/pubsub v1.0.2 // indirect


### PR DESCRIPTION
Uses the [sd_notify API](https://www.freedesktop.org/software/systemd/man/sd_notify.html) to send a readiness notification to systemd, suitable for `Type=notify` services.

Reuses the existing (previously indirect) dependency on `github.com/coreos/go-systemd`