### PR TITLE
Feat/add max concurrent compactions pebble config

### DIFF
--- a/datastore/pebble/config.go
+++ b/datastore/pebble/config.go
@@ -107,6 +107,7 @@ type pebbleOptions struct {
 	ReadOnly                    bool                      `json:"read_only"`
 	WALBytesPerSync             int                       `json:"wal_bytes_per_sync"`
 	Levels                      []levelOptions            `json:"levels"`
+	MaxConcurrentCompactions    int                       `json:"max_concurrent_compactions"`
 }
 
 func (po *pebbleOptions) Unmarshal() *pebble.Options {
@@ -133,6 +134,7 @@ func (po *pebbleOptions) Unmarshal() *pebble.Options {
 	pebbleOpts.MemTableStopWritesThreshold = po.MemTableStopWritesThreshold
 	pebbleOpts.ReadOnly = po.ReadOnly
 	pebbleOpts.WALBytesPerSync = po.WALBytesPerSync
+	pebbleOpts.MaxConcurrentCompactions = func() int { return po.MaxConcurrentCompactions }
 	return pebbleOpts
 }
 
@@ -158,6 +160,7 @@ func (po *pebbleOptions) Marshal(pebbleOpts *pebble.Options) {
 	po.MemTableStopWritesThreshold = pebbleOpts.MemTableStopWritesThreshold
 	po.ReadOnly = pebbleOpts.ReadOnly
 	po.WALBytesPerSync = pebbleOpts.WALBytesPerSync
+	po.MaxConcurrentCompactions = pebbleOpts.MaxConcurrentCompactions()
 }
 
 // levelOptions carries options for pebble's per-level parameters.

--- a/datastore/pebble/config_test.go
+++ b/datastore/pebble/config_test.go
@@ -35,7 +35,8 @@ var cfgJSON = []byte(`
         "mem_table_size": 4194304,
         "mem_table_stop_writes_threshold": 2,
         "read_only": false,
-        "wal_bytes_per_sync": 0
+        "wal_bytes_per_sync": 0,
+		"max_concurrent_compactions": 2
     }
 }
 `)
@@ -58,6 +59,10 @@ func TestToJSON(t *testing.T) {
 
 	if !cfg.PebbleOptions.DisableWAL {
 		t.Fatal("Disable WAL should be true")
+	}
+
+	if cfg.PebbleOptions.MaxConcurrentCompactions() != 2 {
+		t.Fatalf("Wrong max concuncurrent compactions value, got: %d, want: %d", cfg.PebbleOptions.MaxConcurrentCompactions(), 2)
 	}
 
 	newjson, err := cfg.ToJSON()

--- a/datastore/pebble/config_test.go
+++ b/datastore/pebble/config_test.go
@@ -36,7 +36,7 @@ var cfgJSON = []byte(`
         "mem_table_stop_writes_threshold": 2,
         "read_only": false,
         "wal_bytes_per_sync": 0,
-		"max_concurrent_compactions": 2
+        "max_concurrent_compactions": 2
     }
 }
 `)


### PR DESCRIPTION
This PR solves #1895. 
It adds the MaxConcurrentCompactions pebble config option to the json config so this property can be customized.