### PR TITLE
Add support for configurable pinning only on untrusted peers

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -136,8 +136,10 @@ func (c *Cluster) filterMetrics(ctx context.Context, mSet api.MetricsSet, numMet
 				// discard blacklisted peers
 				continue
 			case c.config.PinOnlyOnTrustedPeers && !c.consensus.IsTrustedPeer(ctx, m.Peer):
-				// discard peer that are not trusted when
-				// configured.
+				// discard peers that are not trusted
+				continue
+			case c.config.PinOnlyOnUntrustedPeers && c.consensus.IsTrustedPeer(ctx, m.Peer):
+				// discard peers that are trusted
 				continue
 			case containsPeer(currentAllocs, m.Peer):
 				curPeersMap[m.Peer] = append(curPeersMap[m.Peer], m)

--- a/cluster_config_test.go
+++ b/cluster_config_test.go
@@ -213,6 +213,22 @@ func TestLoadJSON(t *testing.T) {
 			t.Error("default conn manager values not set")
 		}
 	})
+
+	t.Run("expected pin_only_on_untrusted_peers", func(t *testing.T) {
+		cfg, err := loadJSON2(
+			t,
+			func(j *configJSON) {
+				j.PinOnlyOnTrustedPeers = false
+				j.PinOnlyOnUntrustedPeers = true
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cfg.PinOnlyOnUntrustedPeers {
+			t.Error("expected pin_only_on_untrusted_peers to be true")
+		}
+	})
 }
 
 func TestToJSON(t *testing.T) {
@@ -280,6 +296,13 @@ func TestValidate(t *testing.T) {
 
 	cfg.Default()
 	cfg.PinRecoverInterval = 0
+	if cfg.Validate() == nil {
+		t.Fatal("expected error validating")
+	}
+
+	cfg.Default()
+	cfg.PinOnlyOnTrustedPeers = true
+	cfg.PinOnlyOnUntrustedPeers = true
 	if cfg.Validate() == nil {
 		t.Fatal("expected error validating")
 	}


### PR DESCRIPTION
Fixes #1976

This PR adds support for pinning only on untrusted peers. This feature is enabled via a new `pin_only_on_untrusted_peers` config setting (default `false`).

> This feature is the inverse of the existing `pin_only_on_trusted_peers`.

Configuring both `pin_only_on_trusted_peers` and `pin_only_on_untrusted_peers` to `true` results in a config validation error.