### PR TITLE
pebble: fix and improve debug logging / safe settings

### DIFF
--- a/datastore/pebble/config.go
+++ b/datastore/pebble/config.go
@@ -89,6 +89,7 @@ type Config struct {
 // pebbleOptions is a subset of pebble.Options so it can be marshaled by us in
 // the cluster configuration.
 type pebbleOptions struct {
+	EventListener               *pebble.EventListener     `json:"-"`
 	CacheSizeBytes              int64                     `json:"cache_size_bytes"`
 	BytesPerSync                int                       `json:"bytes_per_sync"`
 	DisableWAL                  bool                      `json:"disable_wal"`
@@ -215,9 +216,12 @@ func (cfg *Config) ConfigKey() string {
 // Default initializes this Config with sensible values.
 func (cfg *Config) Default() error {
 	cfg.Folder = DefaultSubFolder
-	cfg.PebbleOptions.Logger = logger
-
 	cfg.PebbleOptions = DefaultPebbleOptions
+
+	cfg.PebbleOptions.Logger = logger
+	eventListener := pebble.MakeLoggingEventListener(logger)
+	cfg.PebbleOptions.EventListener = &eventListener
+
 	cache := pebble.NewCache(DefaultCacheSize)
 	cfg.PebbleOptions.Cache = cache
 	cfg.PebbleOptions.FormatMajorVersion = DefaultFormatMajorVersion

--- a/datastore/pebble/config.go
+++ b/datastore/pebble/config.go
@@ -102,12 +102,12 @@ type pebbleOptions struct {
 	L0StopWritesThreshold       int                       `json:"l0_stop_writes_threshold"`
 	LBaseMaxBytes               int64                     `json:"l_base_max_bytes"`
 	MaxOpenFiles                int                       `json:"max_open_files"`
+	MaxConcurrentCompactions    int                       `json:"max_concurrent_compactions"`
 	MemTableSize                uint64                    `json:"mem_table_size"`
 	MemTableStopWritesThreshold int                       `json:"mem_table_stop_writes_threshold"`
 	ReadOnly                    bool                      `json:"read_only"`
 	WALBytesPerSync             int                       `json:"wal_bytes_per_sync"`
 	Levels                      []levelOptions            `json:"levels"`
-	MaxConcurrentCompactions    int                       `json:"max_concurrent_compactions"`
 }
 
 func (po *pebbleOptions) Unmarshal() *pebble.Options {
@@ -126,15 +126,18 @@ func (po *pebbleOptions) Unmarshal() *pebble.Options {
 	pebbleOpts.L0StopWritesThreshold = po.L0StopWritesThreshold
 	pebbleOpts.LBaseMaxBytes = po.LBaseMaxBytes
 	pebbleOpts.Levels = make([]pebble.LevelOptions, len(po.Levels))
-	for i := range po.Levels {
-		pebbleOpts.Levels[i] = *po.Levels[i].Unmarshal()
-	}
 	pebbleOpts.MaxOpenFiles = po.MaxOpenFiles
+	// Avoid that an empty field results in compactions being disabled.
+	if po.MaxConcurrentCompactions > 0 {
+		pebbleOpts.MaxConcurrentCompactions = func() int { return po.MaxConcurrentCompactions }
+	}
 	pebbleOpts.MemTableSize = po.MemTableSize
 	pebbleOpts.MemTableStopWritesThreshold = po.MemTableStopWritesThreshold
 	pebbleOpts.ReadOnly = po.ReadOnly
 	pebbleOpts.WALBytesPerSync = po.WALBytesPerSync
-	pebbleOpts.MaxConcurrentCompactions = func() int { return po.MaxConcurrentCompactions }
+	for i := range po.Levels {
+		pebbleOpts.Levels[i] = *po.Levels[i].Unmarshal()
+	}
 	return pebbleOpts
 }
 
@@ -269,6 +272,10 @@ func (cfg *Config) ApplyEnvVars() error {
 func (cfg *Config) Validate() error {
 	if cfg.Folder == "" {
 		return errors.New("folder is unset")
+	}
+
+	if cfg.PebbleOptions.MaxConcurrentCompactions() <= 0 {
+		return errors.New("max_concurrent_compactions must be greater than 0")
 	}
 
 	if err := cfg.PebbleOptions.Validate(); err != nil {

--- a/datastore/pebble/config_test.go
+++ b/datastore/pebble/config_test.go
@@ -1,5 +1,3 @@
-//go:build !arm && !386 && !(openbsd && amd64)
-
 package pebble
 
 import (

--- a/logging.go
+++ b/logging.go
@@ -44,7 +44,7 @@ var LoggingFacilitiesExtra = map[string]string{
 	"raftlib":     "ERROR",
 	"badger":      "INFO",
 	"badger3":     "INFO",
-	"pebble":      "INFO",
+	"pebble":      "WARN", // pebble logs with INFO and FATAL only
 }
 
 // SetFacilityLogLevel sets the log level for a given module


### PR DESCRIPTION
Do not overwrite the default max_concurrent_compactions unless the configuration value is > 0.

Fix debug and event logging coming from pebble.