### PR TITLE
Fix #2039: resource manager and re-connection improvements

### DIFF
--- a/cluster_config.go
+++ b/cluster_config.go
@@ -29,23 +29,26 @@ var DefaultListenAddrs = []string{
 
 // Configuration defaults
 const (
-	DefaultEnableRelayHop          = true
-	DefaultStateSyncInterval       = 5 * time.Minute
-	DefaultPinRecoverInterval      = 12 * time.Minute
-	DefaultMonitorPingInterval     = 15 * time.Second
-	DefaultPeerWatchInterval       = 5 * time.Second
-	DefaultReplicationFactor       = -1
-	DefaultLeaveOnShutdown         = false
-	DefaultPinOnlyOnTrustedPeers   = false
-	DefaultPinOnlyOnUntrustedPeers = false
-	DefaultDisableRepinning        = true
-	DefaultPeerstoreFile           = "peerstore"
-	DefaultConnMgrHighWater        = 400
-	DefaultConnMgrLowWater         = 100
-	DefaultConnMgrGracePeriod      = 2 * time.Minute
-	DefaultDialPeerTimeout         = 3 * time.Second
-	DefaultFollowerMode            = false
-	DefaultMDNSInterval            = 10 * time.Second
+	DefaultEnableRelayHop                  = true
+	DefaultStateSyncInterval               = 5 * time.Minute
+	DefaultPinRecoverInterval              = 12 * time.Minute
+	DefaultMonitorPingInterval             = 15 * time.Second
+	DefaultPeerWatchInterval               = 5 * time.Second
+	DefaultReplicationFactor               = -1
+	DefaultLeaveOnShutdown                 = false
+	DefaultPinOnlyOnTrustedPeers           = false
+	DefaultPinOnlyOnUntrustedPeers         = false
+	DefaultDisableRepinning                = true
+	DefaultPeerstoreFile                   = "peerstore"
+	DefaultConnMgrHighWater                = 400
+	DefaultConnMgrLowWater                 = 100
+	DefaultResourceMgrEnabled              = true
+	DefaultResourceMgrMemoryLimitBytes     = 0
+	DefaultResourceMgrFileDescriptorsLimit = 0
+	DefaultConnMgrGracePeriod              = 2 * time.Minute
+	DefaultDialPeerTimeout                 = 3 * time.Second
+	DefaultFollowerMode                    = false
+	DefaultMDNSInterval                    = 10 * time.Second
 )
 
 // ConnMgrConfig configures the libp2p host connection manager.
@@ -53,6 +56,13 @@ type ConnMgrConfig struct {
 	HighWater   int
 	LowWater    int
 	GracePeriod time.Duration
+}
+
+// ResourceMgrConfig configures the libp2p resource manager scaling.
+type ResourceMgrConfig struct {
+	Enabled              bool
+	MemoryLimitBytes     uint64
+	FileDescriptorsLimit uint64
 }
 
 // Config is the configuration object containing customizable variables to
@@ -89,6 +99,10 @@ type Config struct {
 	// the libp2p host.
 	// FIXME: This only applies to ipfs-cluster-service.
 	ConnMgr ConnMgrConfig
+
+	// ResourceMgr holds configuration for the scaling of the libp2p
+	// resource manager limits.
+	ResourceMgr ResourceMgrConfig
 
 	// Sets the default dial timeout for libp2p connections to other
 	// peers.
@@ -180,30 +194,31 @@ type Config struct {
 // saved using JSON. Most configuration keys are converted into simple types
 // like strings, and key names aim to be self-explanatory for the user.
 type configJSON struct {
-	ID                      string             `json:"id,omitempty"`
-	Peername                string             `json:"peername"`
-	PrivateKey              string             `json:"private_key,omitempty" hidden:"true"`
-	Secret                  string             `json:"secret" hidden:"true"`
-	LeaveOnShutdown         bool               `json:"leave_on_shutdown"`
-	ListenMultiaddress      config.Strings     `json:"listen_multiaddress"`
-	AnnounceMultiaddress    config.Strings     `json:"announce_multiaddress"`
-	NoAnnounceMultiaddress  config.Strings     `json:"no_announce_multiaddress"`
-	EnableRelayHop          bool               `json:"enable_relay_hop"`
-	ConnectionManager       *connMgrConfigJSON `json:"connection_manager"`
-	DialPeerTimeout         string             `json:"dial_peer_timeout"`
-	StateSyncInterval       string             `json:"state_sync_interval"`
-	PinRecoverInterval      string             `json:"pin_recover_interval"`
-	ReplicationFactorMin    int                `json:"replication_factor_min"`
-	ReplicationFactorMax    int                `json:"replication_factor_max"`
-	MonitorPingInterval     string             `json:"monitor_ping_interval"`
-	PeerWatchInterval       string             `json:"peer_watch_interval"`
-	MDNSInterval            string             `json:"mdns_interval"`
-	PinOnlyOnTrustedPeers   bool               `json:"pin_only_on_trusted_peers"`
-	PinOnlyOnUntrustedPeers bool               `json:"pin_only_on_untrusted_peers"`
-	DisableRepinning        bool               `json:"disable_repinning"`
-	FollowerMode            bool               `json:"follower_mode,omitempty"`
-	PeerstoreFile           string             `json:"peerstore_file,omitempty"`
-	PeerAddresses           []string           `json:"peer_addresses"`
+	ID                      string                 `json:"id,omitempty"`
+	Peername                string                 `json:"peername"`
+	PrivateKey              string                 `json:"private_key,omitempty" hidden:"true"`
+	Secret                  string                 `json:"secret" hidden:"true"`
+	LeaveOnShutdown         bool                   `json:"leave_on_shutdown"`
+	ListenMultiaddress      config.Strings         `json:"listen_multiaddress"`
+	AnnounceMultiaddress    config.Strings         `json:"announce_multiaddress"`
+	NoAnnounceMultiaddress  config.Strings         `json:"no_announce_multiaddress"`
+	EnableRelayHop          bool                   `json:"enable_relay_hop"`
+	ConnectionManager       *connMgrConfigJSON     `json:"connection_manager"`
+	ResourceManager         *resourceMgrConfigJSON `json:"resource_manager"`
+	DialPeerTimeout         string                 `json:"dial_peer_timeout"`
+	StateSyncInterval       string                 `json:"state_sync_interval"`
+	PinRecoverInterval      string                 `json:"pin_recover_interval"`
+	ReplicationFactorMin    int                    `json:"replication_factor_min"`
+	ReplicationFactorMax    int                    `json:"replication_factor_max"`
+	MonitorPingInterval     string                 `json:"monitor_ping_interval"`
+	PeerWatchInterval       string                 `json:"peer_watch_interval"`
+	MDNSInterval            string                 `json:"mdns_interval"`
+	PinOnlyOnTrustedPeers   bool                   `json:"pin_only_on_trusted_peers"`
+	PinOnlyOnUntrustedPeers bool                   `json:"pin_only_on_untrusted_peers"`
+	DisableRepinning        bool                   `json:"disable_repinning"`
+	FollowerMode            bool                   `json:"follower_mode,omitempty"`
+	PeerstoreFile           string                 `json:"peerstore_file,omitempty"`
+	PeerAddresses           []string               `json:"peer_addresses"`
 }
 
 // connMgrConfigJSON configures the libp2p host connection manager.
@@ -211,6 +226,13 @@ type connMgrConfigJSON struct {
 	HighWater   int    `json:"high_water"`
 	LowWater    int    `json:"low_water"`
 	GracePeriod string `json:"grace_period"`
+}
+
+// resourceMgrConfigJSON configures the libp2p host resource manager.
+type resourceMgrConfigJSON struct {
+	Enabled              bool   `json:"enabled"`
+	MemoryLimitBytes     uint64 `json:"memory_limit_bytes"`
+	FileDescriptorsLimit uint64 `json:"file_descriptors_limit"`
 }
 
 // ConfigKey returns a human-readable string to identify
@@ -389,6 +411,11 @@ func (cfg *Config) setDefaults() {
 		LowWater:    DefaultConnMgrLowWater,
 		GracePeriod: DefaultConnMgrGracePeriod,
 	}
+	cfg.ResourceMgr = ResourceMgrConfig{
+		Enabled:              DefaultResourceMgrEnabled,
+		MemoryLimitBytes:     DefaultResourceMgrMemoryLimitBytes,
+		FileDescriptorsLimit: DefaultResourceMgrFileDescriptorsLimit,
+	}
 	cfg.DialPeerTimeout = DefaultDialPeerTimeout
 	cfg.LeaveOnShutdown = DefaultLeaveOnShutdown
 	cfg.StateSyncInterval = DefaultStateSyncInterval
@@ -470,6 +497,12 @@ func (cfg *Config) applyConfigJSON(jcfg *configJSON) error {
 		}
 	}
 
+	if rmgr := jcfg.ResourceManager; rmgr != nil {
+		cfg.ResourceMgr.Enabled = rmgr.Enabled
+		cfg.ResourceMgr.MemoryLimitBytes = rmgr.MemoryLimitBytes
+		cfg.ResourceMgr.FileDescriptorsLimit = rmgr.FileDescriptorsLimit
+	}
+
 	rplMin := jcfg.ReplicationFactorMin
 	rplMax := jcfg.ReplicationFactorMax
 	config.SetIfNotDefault(rplMin, &cfg.ReplicationFactorMin)
@@ -546,6 +579,11 @@ func (cfg *Config) toConfigJSON() (jcfg *configJSON, err error) {
 		HighWater:   cfg.ConnMgr.HighWater,
 		LowWater:    cfg.ConnMgr.LowWater,
 		GracePeriod: cfg.ConnMgr.GracePeriod.String(),
+	}
+	jcfg.ResourceManager = &resourceMgrConfigJSON{
+		Enabled:              cfg.ResourceMgr.Enabled,
+		MemoryLimitBytes:     cfg.ResourceMgr.MemoryLimitBytes,
+		FileDescriptorsLimit: cfg.ResourceMgr.FileDescriptorsLimit,
 	}
 	jcfg.DialPeerTimeout = cfg.DialPeerTimeout.String()
 	jcfg.StateSyncInterval = cfg.StateSyncInterval.String()

--- a/clusterhost.go
+++ b/clusterhost.go
@@ -311,7 +311,10 @@ func makeResourceMgr(enabled bool, maxMemory, maxFD uint64, connMgrHighWater int
 
 	// Auto-scaled limits based on available memory/fds.
 	if maxMemory == 0 {
-		maxMemory = uint64((float64(memory.TotalMemory()) * 0.85))
+		maxMemory = uint64((float64(memory.TotalMemory()) * 0.25))
+		if maxMemory < 1<<20 { // 1 GiB
+			maxMemory = 1 << 20
+		}
 	}
 	if maxFD == 0 {
 		maxFD = fd.GetNumFDs() / 2

--- a/clusterhost.go
+++ b/clusterhost.go
@@ -5,6 +5,9 @@ import (
 	"encoding/hex"
 
 	config "github.com/ipfs-cluster/ipfs-cluster/config"
+	fd "github.com/ipfs-cluster/ipfs-cluster/internal/fd"
+
+	humanize "github.com/dustin/go-humanize"
 	ipns "github.com/ipfs/boxo/ipns"
 	ds "github.com/ipfs/go-datastore"
 	namespace "github.com/ipfs/go-datastore/namespace"
@@ -19,8 +22,9 @@ import (
 	peer "github.com/libp2p/go-libp2p/core/peer"
 	corepnet "github.com/libp2p/go-libp2p/core/pnet"
 	routing "github.com/libp2p/go-libp2p/core/routing"
-	"github.com/libp2p/go-libp2p/p2p/host/autorelay"
+	autorelay "github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	p2pbhost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	connmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	identify "github.com/libp2p/go-libp2p/p2p/protocol/identify"
 	noise "github.com/libp2p/go-libp2p/p2p/security/noise"
@@ -30,6 +34,7 @@ import (
 	websocket "github.com/libp2p/go-libp2p/p2p/transport/websocket"
 	mafilter "github.com/libp2p/go-maddr-filter"
 	ma "github.com/multiformats/go-multiaddr"
+	memory "github.com/pbnjay/memory"
 	mamask "github.com/whyrusleeping/multiaddr-filter"
 )
 
@@ -71,6 +76,17 @@ func NewClusterHost(
 		return nil, nil, nil, err
 	}
 
+	var rmgr network.ResourceManager
+	if !cfg.ResourceMgr.Enabled {
+		rmgr, err = rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(rcmgr.InfiniteLimits))
+		logger.Infof("go-libp2p Resource Manager DISABLED")
+	} else {
+		rmgr, err = makeResourceMgr(cfg.ResourceMgr.MemoryLimitBytes, cfg.ResourceMgr.FileDescriptorsLimit, cfg.ConnMgr.HighWater)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	var h host.Host
 	var idht *dual.DHT
 	// a channel to wait until these variables have been set
@@ -98,6 +114,7 @@ func NewClusterHost(
 		libp2p.AddrsFactory(addrsFactory),
 		libp2p.NATPortMap(),
 		libp2p.ConnectionManager(connman),
+		libp2p.ResourceManager(rmgr),
 		libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
 			idht, err = newDHT(ctx, h, ds)
 			return idht, err
@@ -286,4 +303,137 @@ func makeAddrsFactory(announce []ma.Multiaddr, noAnnounce []ma.Multiaddr) (p2pbh
 		}
 		return out
 	}, nil
+}
+
+// mostly copy/pasted from https://github.com/ipfs/rainbow/blob/main/rcmgr.go
+// which is itself copy-pasted from Kubo, because libp2p does not have
+// a sane way of doing this.
+func makeResourceMgr(maxMemory, maxFD uint64, connMgrHighWater int) (network.ResourceManager, error) {
+	if maxMemory == 0 {
+		maxMemory = uint64((float64(memory.TotalMemory()) * 0.85))
+	}
+	if maxFD == 0 {
+		maxFD = fd.GetNumFDs() / 2
+	}
+
+	infiniteResourceLimits := rcmgr.InfiniteLimits.ToPartialLimitConfig().System
+	maxMemoryMB := maxMemory / (1024 * 1024)
+
+	// At least as of 2023-01-25, it's possible to open a connection that
+	// doesn't ask for any memory usage with the libp2p Resource Manager/Accountant
+	// (see https://github.com/libp2p/go-libp2p/issues/2010#issuecomment-1404280736).
+	// As a result, we can't currently rely on Memory limits to full protect us.
+	// Until https://github.com/libp2p/go-libp2p/issues/2010 is addressed,
+	// we take a proxy now of restricting to 1 inbound connection per MB.
+	// Note: this is more generous than go-libp2p's default autoscaled limits which do
+	// 64 connections per 1GB
+	// (see https://github.com/libp2p/go-libp2p/blob/master/p2p/host/resource-manager/limit_defaults.go#L357 ).
+	systemConnsInbound := int(1 * maxMemoryMB)
+
+	partialLimits := rcmgr.PartialLimitConfig{
+		System: rcmgr.ResourceLimits{
+			Memory: rcmgr.LimitVal64(maxMemory),
+			FD:     rcmgr.LimitVal(maxFD),
+
+			Conns:         rcmgr.Unlimited,
+			ConnsInbound:  rcmgr.LimitVal(systemConnsInbound),
+			ConnsOutbound: rcmgr.Unlimited,
+
+			Streams:         rcmgr.Unlimited,
+			StreamsOutbound: rcmgr.Unlimited,
+			StreamsInbound:  rcmgr.Unlimited,
+		},
+
+		// Transient connections won't cause any memory to be accounted for by the resource manager/accountant.
+		// Only established connections do.
+		// As a result, we can't rely on System.Memory to protect us from a bunch of transient connection being opened.
+		// We limit the same values as the System scope, but only allow the Transient scope to take 25% of what is allowed for the System scope.
+		Transient: rcmgr.ResourceLimits{
+			Memory: rcmgr.LimitVal64(maxMemory / 4),
+			FD:     rcmgr.LimitVal(maxFD / 4),
+
+			Conns:         rcmgr.Unlimited,
+			ConnsInbound:  rcmgr.LimitVal(systemConnsInbound / 4),
+			ConnsOutbound: rcmgr.Unlimited,
+
+			Streams:         rcmgr.Unlimited,
+			StreamsInbound:  rcmgr.Unlimited,
+			StreamsOutbound: rcmgr.Unlimited,
+		},
+
+		// Lets get out of the way of the allow list functionality.
+		// If someone specified "Swarm.ResourceMgr.Allowlist" we should let it go through.
+		AllowlistedSystem: infiniteResourceLimits,
+
+		AllowlistedTransient: infiniteResourceLimits,
+
+		// Keep it simple by not having Service, ServicePeer, Protocol, ProtocolPeer, Conn, or Stream limits.
+		ServiceDefault: infiniteResourceLimits,
+
+		ServicePeerDefault: infiniteResourceLimits,
+
+		ProtocolDefault: infiniteResourceLimits,
+
+		ProtocolPeerDefault: infiniteResourceLimits,
+
+		Conn: infiniteResourceLimits,
+
+		Stream: infiniteResourceLimits,
+
+		// Limit the resources consumed by a peer.
+		// This doesn't protect us against intentional DoS attacks since an attacker can easily spin up multiple peers.
+		// We specify this limit against unintentional DoS attacks (e.g., a peer has a bug and is sending too much traffic intentionally).
+		// In that case we want to keep that peer's resource consumption contained.
+		// To keep this simple, we only constrain inbound connections and streams.
+		PeerDefault: rcmgr.ResourceLimits{
+			Memory:          rcmgr.Unlimited64,
+			FD:              rcmgr.Unlimited,
+			Conns:           rcmgr.Unlimited,
+			ConnsInbound:    rcmgr.DefaultLimit,
+			ConnsOutbound:   rcmgr.Unlimited,
+			Streams:         rcmgr.Unlimited,
+			StreamsInbound:  rcmgr.DefaultLimit,
+			StreamsOutbound: rcmgr.Unlimited,
+		},
+	}
+
+	scalingLimitConfig := rcmgr.DefaultLimits
+	libp2p.SetDefaultServiceLimits(&scalingLimitConfig)
+
+	// Anything set above in partialLimits that had a value of rcmgr.DefaultLimit will be overridden.
+	// Anything in scalingLimitConfig that wasn't defined in partialLimits above will be added (e.g., libp2p's default service limits).
+	partialLimits = partialLimits.Build(scalingLimitConfig.Scale(int64(maxMemory), int(maxFD))).ToPartialLimitConfig()
+
+	// Simple checks to override autoscaling ensuring limits make sense versus the connmgr values.
+	// There are ways to break this, but this should catch most problems already.
+	// We might improve this in the future.
+	// See: https://github.com/ipfs/kubo/issues/9545
+	if partialLimits.System.ConnsInbound > rcmgr.DefaultLimit {
+		maxInboundConns := int(partialLimits.System.ConnsInbound)
+		if connmgrHighWaterTimesTwo := connMgrHighWater * 2; maxInboundConns < connmgrHighWaterTimesTwo {
+			maxInboundConns = connmgrHighWaterTimesTwo
+		}
+
+		if maxInboundConns < 800 {
+			maxInboundConns = 800
+		}
+
+		// Scale System.StreamsInbound as well, but use the existing ratio of StreamsInbound to ConnsInbound
+		if partialLimits.System.StreamsInbound > rcmgr.DefaultLimit {
+			partialLimits.System.StreamsInbound = rcmgr.LimitVal(int64(maxInboundConns) * int64(partialLimits.System.StreamsInbound) / int64(partialLimits.System.ConnsInbound))
+		}
+		partialLimits.System.ConnsInbound = rcmgr.LimitVal(maxInboundConns)
+	}
+
+	logger.Infof("go-libp2p Resource Manager ENABLED: Limits based on max_memory: %s, max_fds: %d", humanize.Bytes(maxMemory), maxFD)
+
+	// We already have a complete value thus pass in an empty ConcreteLimitConfig.
+	limitCfg := partialLimits.Build(rcmgr.ConcreteLimitConfig{})
+
+	mgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(limitCfg))
+	if err != nil {
+		return nil, err
+	}
+
+	return mgr, nil
 }

--- a/cmd/ipfs-cluster-follow/commands.go
+++ b/cmd/ipfs-cluster-follow/commands.go
@@ -314,7 +314,7 @@ func runCmd(c *cli.Context) error {
 	// Defaults to Trusted otherwise.
 	cfgs.Cluster.RPCPolicy["Cluster.RepoGCLocal"] = ipfscluster.RPCClosed
 
-	// Discard API configurations and create our own
+	// Discard API configurations and create our own (unix socket)
 	apiCfg := rest.NewConfig()
 	cfgs.Restapi = apiCfg
 	_ = apiCfg.Default()

--- a/internal/fd/fd.go
+++ b/internal/fd/fd.go
@@ -1,0 +1,2 @@
+// Package fd is used to obtain the available number of file descriptors.
+package fd

--- a/internal/fd/sys_not_unix.go
+++ b/internal/fd/sys_not_unix.go
@@ -1,0 +1,10 @@
+//go:build !(aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
+
+package fd
+
+import "math"
+
+// GetNumFDs returns the File Descriptors for non unix systems as MaxInt.
+func GetNumFDs() uint64 {
+	return math.MaxUInt64
+}

--- a/internal/fd/sys_unix.go
+++ b/internal/fd/sys_unix.go
@@ -1,0 +1,16 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package fd
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// GetNumFDs returns the File Descriptors limit.
+func GetNumFDs() uint64 {
+	var l unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &l); err != nil {
+		return 0
+	}
+	return l.Cur
+}

--- a/pstoremgr/pstoremgr.go
+++ b/pstoremgr/pstoremgr.go
@@ -188,10 +188,24 @@ func (pm *Manager) PeerInfos(peers []peer.ID) []peer.AddrInfo {
 // given connect parameter. Peers are tagged with priority as given
 // by their position in the list.
 func (pm *Manager) ImportPeers(addrs []ma.Multiaddr, connect bool, ttl time.Duration) error {
-	for i, a := range addrs {
+	prio := 1
+	for _, a := range addrs {
 		pid, err := pm.ImportPeer(a, connect, ttl)
 		if err == nil {
-			pm.SetPriority(pid, i)
+			pm.SetPriority(pid, prio)
+			prio++
+		}
+	}
+	return nil
+}
+
+// ImportPeersWithPriority calls ImportPeer for every address in the given
+// slice, using the given connect parameter. Peers are tagged with the given priority.
+func (pm *Manager) ImportPeersWithPriority(addrs []ma.Multiaddr, connect bool, ttl time.Duration, priority int) error {
+	for _, a := range addrs {
+		pid, err := pm.ImportPeer(a, connect, ttl)
+		if err == nil {
+			pm.SetPriority(pid, priority)
 		}
 	}
 	return nil
@@ -290,14 +304,20 @@ func (pm *Manager) SavePeerstoreForPeers(peers []peer.ID) error {
 	return pm.SavePeerstore(pm.PeerInfos(peers))
 }
 
-// Bootstrap attempts to get up to "count" connected peers by trying those
-// in the peerstore in priority order. It returns the list of peers it managed
-// to connect to.
-func (pm *Manager) Bootstrap(count int, byPriority bool) []peer.ID {
-	totalConns := len(pm.host.Network().Conns())
-	// short-cut if there will be nothing to do.
-	if totalConns >= count {
-		return nil
+// Bootstrap attempts to get up to "count" connected peers.  When byPriority
+// is true it will order the peers based on their priority tags and attempt to
+// connect in that order.  When force is true it will attempt to connect to
+// "count" number of peers regardless of the number of existing
+// connections. It returns the list of peers it managed to connect to.
+func (pm *Manager) Bootstrap(count int, byPriority bool, force bool) []peer.ID {
+	totalConns := 0
+
+	if !force {
+		totalConns = len(pm.host.Network().Conns())
+		// short-cut if there will be nothing to do.
+		if totalConns >= count {
+			return nil
+		}
 	}
 
 	knownPeers := pm.host.Peerstore().PeersWithAddrs()
@@ -319,7 +339,7 @@ func (pm *Manager) Bootstrap(count int, byPriority bool) []peer.ID {
 
 	// keep conecting while we have peers in the store
 	// and we have not reached count.
-	for i := 0; i < lenKnown && totalConns < count; i++ {
+	for i := 0; i < lenKnown && (totalConns < count); i++ {
 		pinfo := pinfos[i]
 		ctx, cancel := context.WithTimeout(pm.ctx, ConnectTimeout)
 		defer cancel()
@@ -396,6 +416,12 @@ func (ps *peerSort) Less(i, j int) bool {
 	if err == nil {
 		prio2 = prio2iface.(int)
 	}
+
+	// Randomize order
+	if prio1 == prio2 {
+		return rand.Intn(2) == 0
+	}
+
 	return prio1 < prio2
 }
 


### PR DESCRIPTION
To address the issues in #2039 this adds control of the libp2p resource managers and improves the "reBootstrap" logic so that peers do not continuously reconnect to the 3 most-prioritary peers in the cluster.

