### PR TITLE
config: util.Strings with 0 length should json.Marshal as "[]"

### DIFF
--- a/config/util.go
+++ b/config/util.go
@@ -208,7 +208,7 @@ func (o *Strings) UnmarshalJSON(data []byte) error {
 func (o Strings) MarshalJSON() ([]byte, error) {
 	switch len(o) {
 	case 0:
-		return json.Marshal(nil)
+		return json.Marshal([]string{})
 	case 1:
 		return json.Marshal(o[0])
 	default:


### PR DESCRIPTION
Empty defaults should become an empty array and not "null", even if a single string is understood as value for Unmarshaling.