### PR TITLE
Expose libp2p metrics and bandwidth stats for libp2p protocols

### DIFF
--- a/api/rest/client/client.go
+++ b/api/rest/client/client.go
@@ -101,6 +101,10 @@ type Client interface {
 	// metrics etc.).
 	Alerts(ctx context.Context) ([]api.Alert, error)
 
+	// BandwidthByProtocol returns bandwidth stats for each libp2p
+	// protocol used.
+	BandwidthByProtocol(ctx context.Context) (api.BandwidthByProtocol, error)
+
 	// Version returns the ipfs-cluster peer's version.
 	Version(context.Context) (api.Version, error)
 
@@ -122,9 +126,9 @@ type Client interface {
 	// returns collected CIDs. If local is true, it would garbage collect
 	// only on contacted peer, otherwise on all peers' IPFS daemons.
 	RepoGC(ctx context.Context, local bool) (api.GlobalRepoGC, error)
-	
+
 	// Health returns no content when everything is ok, and an error otherwise
-	Health(ctx context.Context) (error)
+	Health(ctx context.Context) error
 }
 
 // Config allows to configure the parameters to connect

--- a/api/rest/client/lbclient.go
+++ b/api/rest/client/lbclient.go
@@ -400,6 +400,18 @@ func (lc *loadBalancingClient) Alerts(ctx context.Context) ([]api.Alert, error) 
 	return alerts, err
 }
 
+func (lc *loadBalancingClient) BandwidthByProtocol(ctx context.Context) (api.BandwidthByProtocol, error) {
+	var bw api.BandwidthByProtocol
+	call := func(c Client) error {
+		var err error
+		bw, err = c.BandwidthByProtocol(ctx)
+		return err
+	}
+
+	err := lc.retry(0, call)
+	return bw, err
+}
+
 // Version returns the ipfs-cluster peer's version.
 func (lc *loadBalancingClient) Version(ctx context.Context) (api.Version, error) {
 	var v api.Version

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -350,6 +350,16 @@ func (c *defaultClient) Alerts(ctx context.Context) ([]api.Alert, error) {
 	return alerts, err
 }
 
+// BandwidthByProtocol returns bandwidth stats for each libp2p protocol used.
+func (c *defaultClient) BandwidthByProtocol(ctx context.Context) (api.BandwidthByProtocol, error) {
+	ctx, span := trace.StartSpan(ctx, "client/Alert")
+	defer span.End()
+
+	var bw api.BandwidthByProtocol
+	err := c.do(ctx, "GET", "/health/bandwidth", nil, nil, &bw)
+	return bw, err
+}
+
 // Version returns the ipfs-cluster peer's version.
 func (c *defaultClient) Version(ctx context.Context) (api.Version, error) {
 	ctx, span := trace.StartSpan(ctx, "client/Version")

--- a/api/rest/client/methods_test.go
+++ b/api/rest/client/methods_test.go
@@ -519,6 +519,27 @@ func TestAlerts(t *testing.T) {
 	testClients(t, api, testF)
 }
 
+func TestBandwidthByProtocol(t *testing.T) {
+	ctx := context.Background()
+	api := testAPI(t)
+	defer shutdown(api)
+
+	testF := func(t *testing.T, c Client) {
+		bw, err := c.BandwidthByProtocol(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bw) != 2 {
+			t.Fatal("expected 2 protocols")
+		}
+		if p1 := bw["protocol1"]; p1.TotalIn != 10 {
+			t.Error("expected different bandwidth stats")
+		}
+	}
+
+	testClients(t, api, testF)
+}
+
 func TestGetConnectGraph(t *testing.T) {
 	ctx := context.Background()
 	api := testAPI(t)
@@ -910,7 +931,7 @@ func TestHealth(t *testing.T) {
 	defer shutdown(api)
 
 	testF := func(t *testing.T, c Client) {
-		 err := c.Health(ctx)
+		err := c.Health(ctx)
 		if err != nil {
 			t.Log(err)
 			t.Error("expected no errors")

--- a/api/rest/restapi.go
+++ b/api/rest/restapi.go
@@ -181,6 +181,12 @@ func (api *API) routes(c *rpc.Client) []common.Route {
 			HandlerFunc: api.alertsHandler,
 		},
 		{
+			Name:        "Bandwidth by protocol stats",
+			Method:      "GET",
+			Pattern:     "/health/bandwidth",
+			HandlerFunc: api.bandwidthByProtocolHandler,
+		},
+		{
 			Name:        "Metrics",
 			Method:      "GET",
 			Pattern:     "/monitor/metrics/{name}",
@@ -288,6 +294,19 @@ func (api *API) alertsHandler(w http.ResponseWriter, r *http.Request) {
 		&alerts,
 	)
 	api.SendResponse(w, common.SetStatusAutomatically, err, alerts)
+}
+
+func (api *API) bandwidthByProtocolHandler(w http.ResponseWriter, r *http.Request) {
+	var bw types.BandwidthByProtocol
+	err := api.rpcClient.CallContext(
+		r.Context(),
+		"",
+		"Cluster",
+		"BandwidthByProtocol",
+		struct{}{},
+		&bw,
+	)
+	api.SendResponse(w, common.SetStatusAutomatically, err, bw)
 }
 
 func (api *API) addHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/rest/restapi_test.go
+++ b/api/rest/restapi_test.go
@@ -608,6 +608,22 @@ func TestAPIAlertsEndpoint(t *testing.T) {
 	test.BothEndpoints(t, tf)
 }
 
+func TestAPIBandwidthByProtocolEndpoint(t *testing.T) {
+	ctx := context.Background()
+	rest := testAPI(t)
+	defer rest.Shutdown(ctx)
+
+	tf := func(t *testing.T, url test.URLFunc) {
+		var resp api.BandwidthByProtocol
+		test.MakeGet(t, rest, url(rest)+"/health/bandwidth", &resp)
+		if len(resp) != 2 {
+			t.Error("expected two protocols")
+		}
+	}
+
+	test.BothEndpoints(t, tf)
+}
+
 func TestAPIStatusAllEndpoint(t *testing.T) {
 	ctx := context.Background()
 	rest := testAPI(t)

--- a/api/types.go
+++ b/api/types.go
@@ -1411,6 +1411,18 @@ type Alert struct {
 	TriggeredAt time.Time `json:"triggered_at" codec:"r,omitempty"`
 }
 
+// Bandwidth carries bandwidth information per libp2p/core/metrics.Stats.
+type Bandwidth struct {
+	TotalIn  int64   `json:"total_in" codec:"i,omitempty"`
+	TotalOut int64   `json:"total_out" codec:"o,omitempty"`
+	RateIn   float64 `json:"rate_in" codec:"ri,omitempty"`
+	RateOut  float64 `json:"rate_out" codec:"ro,omitempty"`
+}
+
+// BandwidthByProtocol carries Bandwidth information indexed by libp2p
+// protocol tag.
+type BandwidthByProtocol map[protocol.ID]Bandwidth
+
 // Error can be used by APIs to return errors.
 type Error struct {
 	Code    int    `json:"code" codec:"o,omitempty"`

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -208,6 +208,7 @@ func testingCluster(t *testing.T) (*Cluster, *mockAPI, *mockConnector, PinTracke
 	cl, err := NewCluster(
 		ctx,
 		host,
+		nil,
 		dht,
 		clusterCfg,
 		store,

--- a/clusterhost.go
+++ b/clusterhost.go
@@ -6,6 +6,7 @@ import (
 
 	config "github.com/ipfs-cluster/ipfs-cluster/config"
 	fd "github.com/ipfs-cluster/ipfs-cluster/internal/fd"
+	"github.com/ipfs-cluster/ipfs-cluster/observations"
 
 	humanize "github.com/dustin/go-humanize"
 	ipns "github.com/ipfs/boxo/ipns"
@@ -117,6 +118,7 @@ func NewClusterHost(
 		libp2p.EnableRelay(),
 		libp2p.EnableAutoRelayWithPeerSource(newPeerSource(hostGetter, dhtGetter)),
 		libp2p.EnableHolePunching(),
+		libp2p.PrometheusRegisterer(observations.PromRegistry),
 	}
 
 	if cfg.EnableRelayHop {

--- a/cmd/ipfs-cluster-ctl/formatters.go
+++ b/cmd/ipfs-cluster-ctl/formatters.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ipfs-cluster/ipfs-cluster/api"
+	"github.com/libp2p/go-libp2p/core/protocol"
 
 	humanize "github.com/dustin/go-humanize"
 )
@@ -86,6 +87,8 @@ func textFormatObject(resp interface{}) {
 		textFormatPrintMetric(r)
 	case api.Alert:
 		textFormatPrintAlert(r)
+	case api.BandwidthByProtocol:
+		textFormatPrintBandwidthByProtocol(r)
 	case chan api.ID:
 		for item := range r {
 			textFormatObject(item)
@@ -278,6 +281,23 @@ func textFormatPrintAlert(obj api.Alert) {
 		humanize.Time(time.Unix(0, obj.Expire)),
 		humanize.Time(obj.TriggeredAt),
 	)
+}
+
+func textFormatPrintBandwidthByProtocol(obj api.BandwidthByProtocol) {
+	var keys []string
+	for k := range obj {
+		keys = append(keys, string(k))
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		stat := obj[protocol.ID(k)]
+		fmt.Printf("%25s: In: %7s. Out: %7s. RateIn: %.2fB/s. RateOut: %.2fB/s\n",
+			k, humanize.Bytes(uint64(stat.TotalIn)), humanize.Bytes(uint64(stat.TotalOut)),
+			stat.RateIn, stat.RateOut,
+		)
+	}
 }
 
 func textFormatPrintGlobalRepoGC(obj api.GlobalRepoGC) {

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -1080,6 +1080,19 @@ trigger automatic repinnings if configured.
 						return nil
 					},
 				},
+				{
+					Name:  "bandwidth",
+					Usage: "Lists bandwidth stats for libp2p protocols",
+					Description: `
+This command lists information about bytes sent, received and current bandwidth
+rates for each libp2p protocol that the peer uses.
+`,
+					Action: func(c *cli.Context) error {
+						resp, cerr := globalClient.BandwidthByProtocol(ctx)
+						formatResponse(c, resp, cerr)
+						return nil
+					},
+				},
 			},
 		},
 		{

--- a/cmd/ipfs-cluster-follow/commands.go
+++ b/cmd/ipfs-cluster-follow/commands.go
@@ -303,7 +303,7 @@ func runCmd(c *cli.Context) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	host, pubsub, dht, err := ipfscluster.NewClusterHost(ctx, cfgHelper.Identity(), cfgs.Cluster, store)
+	host, bwc, pubsub, dht, err := ipfscluster.NewClusterHost(ctx, cfgHelper.Identity(), cfgs.Cluster, store)
 	if err != nil {
 		return cli.Exit(errors.Wrap(err, "error creating libp2p components"), 1)
 	}
@@ -415,6 +415,7 @@ func runCmd(c *cli.Context) error {
 	cluster, err := ipfscluster.NewCluster(
 		ctx,
 		host,
+		bwc,
 		dht,
 		cfgs.Cluster,
 		store,

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -27,6 +27,7 @@ import (
 	dual "github.com/libp2p/go-libp2p-kad-dht/dual"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	host "github.com/libp2p/go-libp2p/core/host"
+	metrics "github.com/libp2p/go-libp2p/core/metrics"
 	peer "github.com/libp2p/go-libp2p/core/peer"
 
 	ma "github.com/multiformats/go-multiaddr"
@@ -93,10 +94,10 @@ func daemon(c *cli.Context) error {
 
 	store := setupDatastore(cfgHelper)
 
-	host, pubsub, dht, err := ipfscluster.NewClusterHost(ctx, cfgHelper.Identity(), cfgs.Cluster, store)
+	host, bwc, pubsub, dht, err := ipfscluster.NewClusterHost(ctx, cfgHelper.Identity(), cfgs.Cluster, store)
 	checkErr("creating libp2p host", err)
 
-	cluster, err := createCluster(ctx, c, cfgHelper, host, pubsub, dht, store, raftStaging)
+	cluster, err := createCluster(ctx, c, cfgHelper, host, bwc, pubsub, dht, store, raftStaging)
 	checkErr("starting cluster", err)
 
 	// noop if no bootstraps
@@ -127,6 +128,7 @@ func createCluster(
 	c *cli.Context,
 	cfgHelper *cmdutils.ConfigHelper,
 	host host.Host,
+	bwc metrics.Reporter,
 	pubsub *pubsub.PubSub,
 	dht *dual.DHT,
 	store ds.Datastore,
@@ -240,6 +242,7 @@ func createCluster(
 	return ipfscluster.NewCluster(
 		ctx,
 		host,
+		bwc,
 		dht,
 		cfgs.Cluster,
 		store,

--- a/go.mod
+++ b/go.mod
@@ -180,7 +180,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.15.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
@@ -211,7 +211,7 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/sys v0.19.0
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -302,7 +302,7 @@ func makeConsensus(t *testing.T, store ds.Datastore, h host.Host, psub *pubsub.P
 }
 
 func createCluster(t *testing.T, host host.Host, dht *dual.DHT, clusterCfg *Config, store ds.Datastore, consensus Consensus, apis []API, ipfs IPFSConnector, tracker PinTracker, mon PeerMonitor, alloc PinAllocator, inf Informer, tracer Tracer) *Cluster {
-	cl, err := NewCluster(context.Background(), host, dht, clusterCfg, store, consensus, apis, ipfs, tracker, mon, alloc, []Informer{inf}, tracer)
+	cl, err := NewCluster(context.Background(), host, nil, dht, clusterCfg, store, consensus, apis, ipfs, tracker, mon, alloc, []Informer{inf}, tracer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/observations/config.go
+++ b/observations/config.go
@@ -22,7 +22,7 @@ const tracingEnvConfigKey = "cluster_tracing"
 const (
 	DefaultEnableStats        = false
 	DefaultPrometheusEndpoint = "/ip4/127.0.0.1/tcp/8888"
-	DefaultReportingInterval  = 2 * time.Second
+	DefaultReportingInterval  = 30 * time.Second
 
 	DefaultEnableTracing       = false
 	DefaultJaegerAgentEndpoint = "/ip4/0.0.0.0/udp/6831"

--- a/observations/setup.go
+++ b/observations/setup.go
@@ -20,6 +20,9 @@ import (
 	"go.opencensus.io/zpages"
 )
 
+// PromRegistry is the metrics Registry used by Cluster.
+var PromRegistry = prom.NewRegistry()
+
 // SetupMetrics configures and starts stats tooling,
 // if enabled.
 func SetupMetrics(cfg *MetricsConfig) error {
@@ -63,13 +66,12 @@ func SetupTracing(cfg *TracingConfig) (*JaegerTracer, error) {
 
 func setupMetrics(cfg *MetricsConfig) error {
 	// setup Prometheus
-	registry := prom.NewRegistry()
 	goCollector := collectors.NewGoCollector()
 	procCollector := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})
-	registry.MustRegister(goCollector, procCollector)
+	PromRegistry.MustRegister(goCollector, procCollector)
 	pe, err := prometheus.NewExporter(prometheus.Options{
 		Namespace: "ipfscluster",
-		Registry:  registry,
+		Registry:  PromRegistry,
 	})
 	if err != nil {
 		return err

--- a/rpc_api.go
+++ b/rpc_api.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ipfs-cluster/ipfs-cluster/state"
 	"github.com/ipfs-cluster/ipfs-cluster/version"
 
-	peer "github.com/libp2p/go-libp2p/core/peer"
 	rpc "github.com/libp2p/go-libp2p-gorpc"
+	peer "github.com/libp2p/go-libp2p/core/peer"
 
 	ocgorpc "github.com/lanzafame/go-libp2p-ocgorpc"
 	"go.opencensus.io/trace"
@@ -424,6 +424,13 @@ func (rpcapi *ClusterRPCAPI) SendInformersMetrics(ctx context.Context, in struct
 func (rpcapi *ClusterRPCAPI) Alerts(ctx context.Context, in struct{}, out *[]api.Alert) error {
 	alerts := rpcapi.c.Alerts()
 	*out = alerts
+	return nil
+}
+
+// BandwidthByProtocol runs Cluster.BandwidthByProtocol().
+func (rpcapi *ClusterRPCAPI) BandwidthByProtocol(ctx context.Context, in struct{}, out *api.BandwidthByProtocol) error {
+	bw := rpcapi.c.BandwidthByProtocol()
+	*out = bw
 	return nil
 }
 

--- a/rpc_policy.go
+++ b/rpc_policy.go
@@ -8,6 +8,7 @@ package ipfscluster
 var DefaultRPCPolicy = map[string]RPCEndpointType{
 	// Cluster methods
 	"Cluster.Alerts":               RPCClosed,
+	"Cluster.BandwidthByProtocol":  RPCClosed,
 	"Cluster.BlockAllocate":        RPCClosed,
 	"Cluster.ConnectGraph":         RPCClosed,
 	"Cluster.ID":                   RPCOpen,
@@ -70,3 +71,4 @@ var DefaultRPCPolicy = map[string]RPCEndpointType{
 	"PeerMonitor.LatestMetrics": RPCClosed,
 	"PeerMonitor.MetricNames":   RPCClosed,
 }
+

--- a/test/rpc_api_mock.go
+++ b/test/rpc_api_mock.go
@@ -422,6 +422,24 @@ func (mock *mockCluster) Alerts(ctx context.Context, in struct{}, out *[]api.Ale
 	return nil
 }
 
+func (mock *mockCluster) BandwidthByProtocol(ctx context.Context, in struct{}, out *api.BandwidthByProtocol) error {
+	*out = api.BandwidthByProtocol{
+		"protocol1": api.Bandwidth{
+			TotalIn:  10,
+			TotalOut: 20,
+			RateIn:   1,
+			RateOut:  2,
+		},
+		"protocol2": api.Bandwidth{
+			TotalIn:  30,
+			TotalOut: 40,
+			RateIn:   3,
+			RateOut:  4,
+		},
+	}
+	return nil
+}
+
 func (mock *mockCluster) IPFSID(ctx context.Context, in peer.ID, out *api.IPFSID) error {
 	var id api.ID
 	_ = mock.ID(ctx, struct{}{}, &id)


### PR DESCRIPTION
This has two parts:

- First, wire in libp2p metrics into the prometheus endpoint. They do not include per-protocol bandwidth metrics but it should have been nevertheless exposed and it was an oversight that it wasn't there.
- Second: add a health/bandwidth endpoint that reports bandwidth stats as given by GetBandwidthByProtocol(). Contains server/client and tests.

`ipfs-cluster-ctl health bandwidth` can be used to display the stats in a prettified way.