### PR TITLE
gossipsub: optimize for diverse clusters with many peers

### DIFF
--- a/clusterhost.go
+++ b/clusterhost.go
@@ -216,12 +216,12 @@ func newPubSub(ctx context.Context, cfg *Config, h host.Host) (*pubsub.PubSub, e
 	// Hearbeat should be rather slow as some peers just may not manage
 	// to handle all incoming publications, so we don't have to deal with
 	// additional IHAVEs too often either.
-	gossipParams.HeartbeatInterval = 10 * time.Second // Default 1
+	gossipParams.HeartbeatInterval = cfg.PubSub.HeartbeatInterval
 
 	// We increase the gap between History gossip and length to give peers
 	// more time to grab messages, but expire announcements rather quick
-	gossipParams.HistoryLength = 6 // 20 * Hearbeat seconds of availability of messages for IWANTs (def 5)
-	gossipParams.HistoryGossip = 2 // 2 * Heartbeat seconds of announcement of messages via IHAVEs (def 3)
+	gossipParams.HistoryLength = cfg.PubSub.HistoryLength // x * Hearbeat seconds of availability of messages for IWANTs (def 5)
+	gossipParams.HistoryGossip = cfg.PubSub.HistoryGossip // x * Heartbeat seconds of announcement of messages via IHAVEs (def 3)
 
 	// Longer Hearbeat intervals means more messages queue up.  IHAVEs
 	// lists may have more message at given moment, so increase this
@@ -235,11 +235,11 @@ func newPubSub(ctx context.Context, cfg *Config, h host.Host) (*pubsub.PubSub, e
 	// have connections to a bunch of peers given DHT etc and having a
 	// tiny mesh only makes more replay necessary. Thus allow me to
 	// increase 4x the defaults.
-	gossipParams.D = 24     // default 6
-	gossipParams.Dlo = 15   // default 5. More leeway.
-	gossipParams.Dhi = 48   // default 12
-	gossipParams.Dout = 8   // default 2
-	gossipParams.Dlazy = 24 // default 6
+	gossipParams.D = cfg.PubSub.DFactor * 6     // default 6
+	gossipParams.Dlo = cfg.PubSub.DFactor * 5   // default 5
+	gossipParams.Dhi = cfg.PubSub.DFactor * 12  // default 12
+	gossipParams.Dout = cfg.PubSub.DFactor * 2  // default 2
+	gossipParams.Dlazy = cfg.PubSub.DFactor * 6 // default 6
 
 	return pubsub.NewGossipSub(
 		ctx,
@@ -251,7 +251,7 @@ func newPubSub(ctx context.Context, cfg *Config, h host.Host) (*pubsub.PubSub, e
 		// prefer messages to just follow the mesh rather than risking
 		// that small peers saturate themselves every time they
 		// publish a metric.
-		pubsub.WithFloodPublish(false),
+		pubsub.WithFloodPublish(cfg.PubSub.FloodPublish),
 		// Custom hash function reduces size of messages and thus traffic.
 		pubsub.WithMessageIdFn(hashMsgID),
 		pubsub.WithPeerOutboundQueueSize(128), // default is 32. Give more leeway to large clusters.

--- a/config_test.go
+++ b/config_test.go
@@ -42,8 +42,8 @@ var testingClusterCfg = []byte(`{
         "heartbeat_interval": "1s",
         "d_factor": 1,
         "history_gossip": 3,
-        "history_length": 6,
-        "flood_publish": true
+        "history_length": 5,
+        "flood_publish": false
     },
     "state_sync_interval": "1m0s",
     "pin_recover_interval": "1m0s",

--- a/config_test.go
+++ b/config_test.go
@@ -30,9 +30,20 @@ var testingClusterCfg = []byte(`{
     "leave_on_shutdown": false,
     "listen_multiaddress": "/ip4/127.0.0.1/tcp/10000",
     "connection_manager": {
-         "high_water": 400,
-         "low_water": 200,
-         "grace_period": "2m0s"
+        "high_water": 400,
+        "low_water": 200,
+        "grace_period": "2m0s"
+    },
+    "resource_manager" : {
+        "enabled": false
+    },
+    "pubsub": {
+        "seen_messages_ttl": "2m",
+        "heartbeat_interval": "1s",
+        "d_factor": 1,
+        "history_gossip": 3,
+        "history_length": 6,
+        "flood_publish": true
     },
     "state_sync_interval": "1m0s",
     "pin_recover_interval": "1m0s",
@@ -134,7 +145,7 @@ var testingPebbleCfg = []byte(`
         "flush_delay_delete_range": 0,
         "flush_delay_range_key": 0,
         "flush_split_bytes": 4194304,
-        "format_major_version": 1,
+        "format_major_version": 16,
         "l0_compaction_file_threshold": 500,
         "l0_compaction_threshold": 4,
         "l0_stop_writes_threshold": 12,

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -355,7 +355,10 @@ func createHost(t *testing.T, priv crypto.PrivKey, clusterSecret []byte, listen 
 
 	// Pubsub needs to be created BEFORE connecting the peers,
 	// otherwise they are not picked up.
-	psub, err := newPubSub(ctx, h)
+	// Note: this is possibly a pubsub bug that was fixed.
+	cfg := &Config{}
+	cfg.Default()
+	psub, err := newPubSub(ctx, cfg, h)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -358,6 +358,7 @@ func createHost(t *testing.T, priv crypto.PrivKey, clusterSecret []byte, listen 
 	// Note: this is possibly a pubsub bug that was fixed.
 	cfg := &Config{}
 	cfg.Default()
+	cfg.LoadJSON(testingClusterCfg)
 	psub, err := newPubSub(ctx, cfg, h)
 	if err != nil {
 		t.Fatal(err)

--- a/ipfscluster_test.go
+++ b/ipfscluster_test.go
@@ -118,14 +118,7 @@ func TestMain(m *testing.M) {
 	}
 
 	for _, f := range customLogLvlFacilities {
-		if _, ok := LoggingFacilities[f]; ok {
-			SetFacilityLogLevel(f, logLevel)
-			continue
-		}
-		if _, ok := LoggingFacilitiesExtra[f]; ok {
-			SetFacilityLogLevel(f, logLevel)
-			continue
-		}
+		SetFacilityLogLevel(f, logLevel)
 	}
 
 	diskInfCfg := &disk.Config{}

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -44,7 +44,7 @@ func peerManagerClusters(t *testing.T) ([]*Cluster, []*test.IpfsMock, host.Host)
 	}
 	wg.Wait()
 
-	// Creat an identity
+	// Create an identity
 	ident, err := config.NewIdentity()
 	if err != nil {
 		t.Fatal(err)
@@ -52,8 +52,6 @@ func peerManagerClusters(t *testing.T) ([]*Cluster, []*test.IpfsMock, host.Host)
 	// Create a config
 	cfg := &Config{}
 	cfg.Default()
-	cfg.PubSub.HeartbeatInterval = time.Second
-	cfg.PubSub.FloodPublish = true
 	listen, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
 	cfg.ListenAddr = []ma.Multiaddr{listen}
 	cfg.Secret = testingClusterSecret

--- a/peer_manager_test.go
+++ b/peer_manager_test.go
@@ -52,6 +52,8 @@ func peerManagerClusters(t *testing.T) ([]*Cluster, []*test.IpfsMock, host.Host)
 	// Create a config
 	cfg := &Config{}
 	cfg.Default()
+	cfg.PubSub.HeartbeatInterval = time.Second
+	cfg.PubSub.FloodPublish = true
 	listen, _ := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/0")
 	cfg.ListenAddr = []ma.Multiaddr{listen}
 	cfg.Secret = testingClusterSecret


### PR DESCRIPTION
See diff. This is an attempt to:

1) Reduce pubsub chatter
2) Reduce pubsub bandwidth
3) Tolerate slower peers better

Rationale: less hearbeats, more leeways, larger mesh for less replays and faster distribution.