### PR TITLE
ipfshttp: improve logic to update informer metrics

### DIFF
--- a/ipfsconn/ipfshttp/config.go
+++ b/ipfsconn/ipfshttp/config.go
@@ -139,7 +139,7 @@ func (cfg *Config) Validate() error {
 		err = errors.New("ipfshttp.repogc_timeout invalid")
 	}
 	if cfg.InformerTriggerInterval < 0 {
-		err = errors.New("ipfshttp.update_metrics_after")
+		err = errors.New("ipfshttp.informer_trigger_interval")
 	}
 
 	return err

--- a/monitor/pubsubmon/pubsubmon.go
+++ b/monitor/pubsubmon/pubsubmon.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ipfs-cluster/ipfs-cluster/monitor/metrics"
 
 	logging "github.com/ipfs/go-log/v2"
-	peer "github.com/libp2p/go-libp2p/core/peer"
 	rpc "github.com/libp2p/go-libp2p-gorpc"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	peer "github.com/libp2p/go-libp2p/core/peer"
 	gocodec "github.com/ugorji/go/codec"
 
 	"go.opencensus.io/trace"


### PR DESCRIPTION
Mainly update informer metrics both at the start and at the end of the pinning operation (always subject to trigger_interval).

Fix some typos.