### PR TITLE
ipfshttp: fix recording total ipfs pins

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -615,7 +615,7 @@ func (ipfs *Connector) PinLs(ctx context.Context, typeFilters []string, out chan
 	var err error
 	var totalPinCount int64
 	defer func() {
-		if err != nil {
+		if err == nil {
 			atomic.StoreInt64(&ipfs.ipfsPinCount, totalPinCount)
 			stats.Record(ipfs.ctx, observations.PinsIpfsPins.M(totalPinCount))
 		}


### PR DESCRIPTION
The number of pins in ipfs should be recorded when NO error happens, and not the otherway around.