### PR TITLE
Fix the error message during the initialization of tags informer

### DIFF
--- a/cmd/ipfs-cluster-follow/commands.go
+++ b/cmd/ipfs-cluster-follow/commands.go
@@ -351,7 +351,7 @@ func runCmd(c *cli.Context) error {
 	if cfgHelper.Manager().IsLoadedFromJSON(config.Informer, cfgs.TagsInf.ConfigKey()) {
 		tagsInf, err := tags.New(cfgs.TagsInf)
 		if err != nil {
-			return cli.Exit(errors.Wrap(err, "creating numpin informer"), 1)
+			return cli.Exit(errors.Wrap(err, "creating tags informer"), 1)
 		}
 		informers = append(informers, tagsInf)
 	}

--- a/cmd/ipfs-cluster-service/daemon.go
+++ b/cmd/ipfs-cluster-service/daemon.go
@@ -192,7 +192,7 @@ func createCluster(
 	}
 	if cfgMgr.IsLoadedFromJSON(config.Informer, cfgs.TagsInf.ConfigKey()) {
 		tagsInf, err := tags.New(cfgs.TagsInf)
-		checkErr("creating numpin informer", err)
+		checkErr("creating tags informer", err)
 		informers = append(informers, tagsInf)
 	}
 


### PR DESCRIPTION
I fixed the error message during the initialization of the tags informer in ipfs-cluster-service and ipfs-cluster-follow because it was the error message for the numpin informer.