### PR TITLE
docker: tag "latest" when releasing

### DIFF
--- a/docker/get-docker-tags.sh
+++ b/docker/get-docker-tags.sh
@@ -44,7 +44,8 @@ if [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc ]]; then
 elif [[ $GIT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echoImageName "$GIT_TAG"
   echoImageName "stable"
-
+  echoImageName "latest" # assume we are not going to be tagging old versions
+  
 elif [ "$GIT_BRANCH" = "master" ]; then
   echoImageName "master-${BUILD_NUM}-${GIT_SHA1_SHORT}"
   echoImageName "master-latest"


### PR DESCRIPTION
The latest tag should be set to the latest release, or at least that is how we used to roll before moving to github-docker-builds.

Fixes #2133.