### PR TITLE
Feat/CLI #2119 Add --wait-limit flag to ipfs-cluster-ctl pin add/rm/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # IPFS Cluster Changelog
 
+### v1.1.3 - Unreleased
+
+IPFS Cluster v1.1.3 is a maintenance release.
+
+#### List of changes
+
+##### Breaking changes
+
+There are no breaking changes on this release.
+
+##### Features
+
+* Added --wait-limit flag to ipfs-cluster-ctl pin add/rm/update. This additional flag controls how many peers should reach the desired status to finish waiting. i.e. ipfs-cluster-ctl pin add --wait-limit 1 will imply --wait and wait for 1 peer to reach status "pinned". For pin/rm same thing. 
+
+##### Bug fixes
+
+* No changes.
+
+##### Other changes
+
+* No changes.
+
+#### Upgrading notices
+
+##### Configuration changes
+
+No changes.
+
+##### REST API
+
+No changes.
+
+##### Pinning Service API
+
+No changes.
+
+##### IPFS Proxy API
+
+No changes.
+
+##### Go APIs
+
+No relevant changes.
+
+##### Other
+
+No changes.
+
+---
+
 ### v1.1.2 - 2024-11-28
 
 IPFS Cluster v1.1.2 is a maintenance release which tunes internal pubsub

--- a/api/rest/client/methods.go
+++ b/api/rest/client/methods.go
@@ -560,7 +560,7 @@ func statusReached(target api.TrackerStatus, gblPinInfo api.GlobalPinInfo, limit
 
 	// Specific case: when limit it set, just count how many targets we
 	// reached.
-	if limit > 0 {
+	if limit > 0 && limit < len(gblPinInfo.PeerMap) {
 		total := 0
 		for _, pinInfo := range gblPinInfo.PeerMap {
 			if pinInfo.Status == target {

--- a/cmd/ipfs-cluster-ctl/main.go
+++ b/cmd/ipfs-cluster-ctl/main.go
@@ -72,6 +72,7 @@ https://github.com/ipfs-cluster/ipfs-cluster.
 
 var (
 	waitFlagDesc        = "Wait for the pin to reach the minimum replication factor before returning"
+	waitLimitFlagDesc   = "This additional flag controls how many peers should reach the desired status to finish waiting."
 	waitTimeoutFlagDesc = "How long to --wait (in seconds). Default: forever"
 )
 
@@ -650,6 +651,10 @@ would still be respected.
 							Name:  "wait, w",
 							Usage: waitFlagDesc,
 						},
+						cli.IntFlag{
+							Name:  "wait-limit, wl",
+							Usage: waitLimitFlagDesc,
+						},
 						cli.DurationFlag{
 							Name:  "wait-timeout, wt",
 							Value: 0,
@@ -728,6 +733,10 @@ although unpinning operations in the cluster may take longer or fail.
 						cli.BoolFlag{
 							Name:  "wait, w",
 							Usage: waitFlagDesc,
+						},
+						cli.IntFlag{
+							Name:  "wait-limit, wl",
+							Usage: waitLimitFlagDesc,
 						},
 						cli.DurationFlag{
 							Name:  "wait-timeout, wt",
@@ -1228,9 +1237,14 @@ func handlePinResponseFormatFlags(
 	var cerr error
 
 	if c.Bool("wait") {
-		limit := 0
-		if target == api.TrackerStatusPinned {
-			limit = pin.ReplicationFactorMin
+		var limit int
+		if c.IsSet("wait-limit") {
+			limit = c.Int("wait-limit")
+		} else {
+			limit = 0
+			if target == api.TrackerStatusPinned {
+				limit = pin.ReplicationFactorMin
+			}
 		}
 		status, cerr = waitFor(pin.Cid, target, c.Duration("wait-timeout"), limit)
 		checkErr("waiting for pin status", cerr)


### PR DESCRIPTION
Fixes #2119. Added CLI --wait-limit flag to ipfs-cluster-ctl pin methods. Also added verification for limit not exceeding the total amount of peers.