### PR TITLE
Fix add nil for unknown multiaddr

### DIFF
--- a/ipfsconn/ipfshttp/ipfshttp.go
+++ b/ipfsconn/ipfshttp/ipfshttp.go
@@ -370,14 +370,14 @@ func (ipfs *Connector) ID(ctx context.Context) (api.IPFSID, error) {
 		ID: pID,
 	}
 
-	mAddrs := make([]api.Multiaddr, len(res.Addresses))
-	for i, strAddr := range res.Addresses {
+	mAddrs := make([]api.Multiaddr, 0, len(res.Addresses))
+	for _, strAddr := range res.Addresses {
 		mAddr, err := api.NewMultiaddr(strAddr)
 		if err != nil {
 			logger.Warningf("cannot parse IPFS multiaddress: %s (%w)... ignoring", strAddr, err)
 			continue
 		}
-		mAddrs[i] = mAddr
+		mAddrs = append(mAddrs, mAddr)
 	}
 	id.Addresses = mAddrs
 	return id, nil


### PR DESCRIPTION
Fix nil pointer panic when using a separate swarm protocol.

```
2025-03-31T03:31:19.035Z        WARN    ipfshttp        ipfshttp/ipfshttp.go:376        cannot parse IPFS multiaddress: /ip4/127.0.0.1/udp/4003/kcp+scop/p2p/12D3Koo... (%!w(*errors.errorString=&{failed to parse multiaddr "/ip4/127.0.0.1/udp/4003/kcp+scop/p2p/12D3Koo...": unknown protocol kcp+scop}))... ignoring
2025-03-31T03:31:19.036Z        INFO    cluster ipfs-cluster/cluster.go:813     IPFS is ready. Peer ID: 12D3Koo...
2025-03-31T03:31:19.036Z        INFO    cluster ipfs-cluster/cluster.go:821     ** IPFS Cluster is READY **
2025-03-31T03:31:19.037Z        WARN    ipfshttp        ipfshttp/ipfshttp.go:376        cannot parse IPFS multiaddress: /ip4/127.0.0.1/udp/4003/kcp+scop/p2p/12D3Koo... (%!w(*errors.errorString=&{failed to parse multiaddr "/ip4/127.0.0.1/udp/4003/kcp+scop/p2p/12D3Koo...": unknown protocol kcp+scop}))... ignoring
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x6061d0]

goroutine 564 [running]:
github.com/multiformats/go-multiaddr.ForEach({0x0?, 0x0?}, 0xc000335af8)
        github.com/multiformats/go-multiaddr@v0.12.4/util.go:168 +0x90
github.com/multiformats/go-multiaddr-dns.Matches(...)
        github.com/multiformats/go-multiaddr-dns@v0.3.1/util.go:10
github.com/ipfs-cluster/ipfs-cluster.publicIPFSAddresses({0xc0060cd2c0?, 0x26?, 0xc0060968c0?})
        github.com/ipfs-cluster/ipfs-cluster/util.go:187 +0xc6
github.com/ipfs-cluster/ipfs-cluster.(*Cluster).sendPingMetric(0xc006196000, {0x1f32908?, 0xc006397890?})
        github.com/ipfs-cluster/ipfs-cluster/cluster.go:404 +0x150
github.com/ipfs-cluster/ipfs-cluster.(*Cluster).pushPingMetrics(0xc006196000, {0x1f32940?, 0xc00651c2d0?})
        github.com/ipfs-cluster/ipfs-cluster/cluster.go:461 +0x11b
github.com/ipfs-cluster/ipfs-cluster.(*Cluster).run.func2()
        github.com/ipfs-cluster/ipfs-cluster/cluster.go:720 +0x59
created by github.com/ipfs-cluster/ipfs-cluster.(*Cluster).run in goroutine 558
        github.com/ipfs-cluster/ipfs-cluster/cluster.go:718 +0xb9
```